### PR TITLE
Use the 'env' option if explicitly provided

### DIFF
--- a/src/now-dotenv.ts
+++ b/src/now-dotenv.ts
@@ -308,7 +308,7 @@ export class NowDotenv {
   }
 
   private readEnvs() {
-    const path = this.options.env || this.options.stage ? `.env.${this.options.stage}` : '.env'
+    const path = this.options.env || (this.options.stage ? `.env.${this.options.stage}` : '.env')
 
     const { parsed, error } = dotenv.config({ path })
 


### PR DESCRIPTION
If the CLI is used with for instance ```now-dotenv sync --env ./.env.prod``` the _env_ option is discarded as the _.env.undefined_ file is passed to _dotenv_.